### PR TITLE
Add automated QA.

### DIFF
--- a/src/illiad-gateway-build-role.ts
+++ b/src/illiad-gateway-build-role.ts
@@ -174,6 +174,16 @@ export class IlliadGatewayBuildRole extends Role {
         ],
       })
     )
+
+    // Allow creating parameters (and delete in case of stack rollback)
+    this.addToPolicy(
+      new PolicyStatement({
+        resources: [
+          Fn.sub('arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/all/illiad-gateway/*'),
+        ],
+        actions: ['ssm:PutParameter', 'ssm:DeleteParameter', 'ssm:AddTagsToResource', 'ssm:RemoveTagsFromResource'],
+      }),
+    )
   }
 }
 

--- a/src/illiad-gateway-qa-project.ts
+++ b/src/illiad-gateway-qa-project.ts
@@ -1,0 +1,51 @@
+import { PipelineProject, BuildSpec, BuildEnvironmentVariableType, LinuxBuildImage } from '@aws-cdk/aws-codebuild'
+import { Role } from '@aws-cdk/aws-iam'
+import { Construct } from '@aws-cdk/core'
+
+export interface IIlliadGatewayQaProjectProps {
+  readonly stage: string
+  readonly role: Role
+}
+
+export class IlliadGatewayQaProject extends PipelineProject {
+  constructor(scope: Construct, id: string, props: IIlliadGatewayQaProjectProps) {
+    const paramStorePath = `/all/illiad-gateway/${props.stage}`
+    const pipelineProps = {
+      role: props.role,
+      environment: {
+        buildImage: LinuxBuildImage.STANDARD_4_0,
+        environmentVariables: {
+          API_URL: {
+            value: `${paramStorePath}/api-url`,
+            type: BuildEnvironmentVariableType.PARAMETER_STORE,
+          },
+          CI: { value: 'true', type: BuildEnvironmentVariableType.PLAINTEXT },
+        },
+      },
+      buildSpec: BuildSpec.fromObject({
+        version: '0.2',
+        phases: {
+          install: {
+            'runtime-versions': {
+              nodejs: '12.x',
+            },
+            commands: [
+              'npm install -g newman',
+              'echo "Ensure that the Newman spec is readable"',
+              'chmod -R 755 ./tests/postman/*',
+            ],
+          },
+          build: {
+            commands: [
+              'echo "Beginning tests at `date`"',
+              `newman run ./tests/postman/qa_collection.json --env-var illiadGatewayApiUrl=$API_URL`,
+            ],
+          },
+        },
+      }),
+    }
+    super(scope, id, pipelineProps)
+  }
+}
+
+export default IlliadGatewayQaProject

--- a/src/illiad-gateway-stack.ts
+++ b/src/illiad-gateway-stack.ts
@@ -138,5 +138,35 @@ export default class IlliadGatewayStack extends cdk.Stack {
       })
       newResource.addMethod('GET', new apigateway.LambdaIntegration(endpoint.lambda))
     })
+
+    // Mock endpoint for automated testing
+    const testResource = api.root.addResource('test')
+    const mockIntegrationOptions = {
+      integrationResponses: [
+        {
+          statusCode: '200',
+        },
+      ],
+      requestTemplates: {
+        "application/json": `{ "statusCode": 200 }`
+      }
+    }
+    testResource.addMethod('GET', new apigateway.MockIntegration(mockIntegrationOptions), {
+      methodResponses: [
+        {
+          statusCode: '200',
+          responseModels: {
+            "application/json": new apigateway.EmptyModel(),
+          },
+        },
+      ],
+    })
+
+    // Output API url to ssm so we can import it in the QA project
+    new StringParameter(this, 'ApiUrlParameter', {
+      parameterName: `${paramStorePath}/api-url`,
+      description: 'Path to root of the API gateway.',
+      stringValue: api.url,
+    })
   }
 }


### PR DESCRIPTION
I know a mock endpoint isn't ideal, but the other ones all require authentication. I can at least call a regular endpoint and make sure it returns Unauthorized, then the mock endpoint to see that we can get a 200 from the API.